### PR TITLE
[BugFix] Parser Unittest 빌드시 Link 오류 수정

### DIFF
--- a/UnitTest/File_Unittest.cpp
+++ b/UnitTest/File_Unittest.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 #include "../GCR Project/File.cpp"
-#include "../GCR Project/Parser.cpp"
+#include "../GCR Project/Parser.h"
 
 TEST(FileTest, FileSelfTest1) {
 	File file = File();


### PR DESCRIPTION
Parser.cpp를 include하여 발생하는 문제로 header include로 변경하였습니다.