### PR TITLE
[BugFix] EmployManager_Unittest2의 cpp include 제거

### DIFF
--- a/UnitTest/EmployeeManager_Unittest2.cpp
+++ b/UnitTest/EmployeeManager_Unittest2.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 #include <vector>
-#include "../GCR Project/EmployeeManager.cpp"
+#include "../GCR Project/EmployeeManager.h"
 #include "../GCR Project/Employee.h"
 
 using namespace std;


### PR DESCRIPTION
EmployManager_Unittest2 에서 EmployManager의 cpp구현부를 include하는 것을 Header include로 전환합니다.

Signed-off-by: Dowon Park <dowon.park@gmail.com>