### PR TITLE
[Refactoring] EmployeeManager refactoring

### DIFF
--- a/GCR Project/EmployeeManager.h
+++ b/GCR Project/EmployeeManager.h
@@ -1,51 +1,170 @@
 #pragma once
 #include <iostream>
 #include <string>
+#include <vector>
 #include <map>
-#include "Employee.h"
 
+#include "Employee.h"
+#include "common.h"
+
+/////////////////////////////////////
+//// Searcher
+////////////////////////////////////
+class Searcher {
+public:
+	Searcher(std::map<int, Employee>* pEmployees) : pEmployees_(pEmployees) {}
+	virtual ~Searcher() {}
+	virtual std::map<int, Employee> search(const Option& option) const = 0;
+
+protected:
+	std::map<int, Employee>* pEmployees_;
+};
+
+class EmployeeNumSearcher : public Searcher {
+public:
+	EmployeeNumSearcher(std::map<int, Employee>* pEmployees) : Searcher(pEmployees) {}
+
+private:
+	virtual std::map<int, Employee> search(const Option& option) const override;
+};
+
+class NameSearcher : public Searcher {
+public:
+	NameSearcher(std::map<int, Employee>* pEmployees) : Searcher(pEmployees) {}
+
+private:
+	virtual std::map<int, Employee> search(const Option& option) const override;
+	std::string getOption2String(const std::string& name, const OPTION2 option) const;
+};
+
+class ClSearcher : public Searcher {
+public:
+	ClSearcher(std::map<int, Employee>* pEmployees) : Searcher(pEmployees) {}
+
+private:
+	virtual std::map<int, Employee> search(const Option& option) const override;
+};
+
+class PhoneNumSearcher : public Searcher {
+public:
+	PhoneNumSearcher(std::map<int, Employee>* pEmployees) : Searcher(pEmployees) {}
+
+private:
+	virtual std::map<int, Employee> search(const Option& option) const override;
+	std::string getOption2String(const std::string& name, const OPTION2 option) const;
+};
+
+class BirthdaySearcher : public Searcher {
+public:
+	BirthdaySearcher(std::map<int, Employee>* pEmployees) : Searcher(pEmployees) {}
+
+private:
+	virtual std::map<int, Employee> search(const Option& option) const override;
+	std::string getOption2String(const std::string& name, const OPTION2 option) const;
+};
+
+class CertiSearcher : public Searcher {
+public:
+	CertiSearcher(std::map<int, Employee>* pEmployees) : Searcher(pEmployees) {}
+
+private:
+	virtual std::map<int, Employee> search(const Option& option) const override;
+};
+
+class IFactorySearcher {
+public:
+	virtual ~IFactorySearcher() {}
+	virtual Searcher* getConcreteSearcher(const Option& option) const = 0;
+};
+
+class FactorySearcher : public IFactorySearcher {
+public:
+	FactorySearcher(std::map<int, Employee>* pEmployees);
+	~FactorySearcher();
+
+private:
+	virtual Searcher* getConcreteSearcher(const Option& option) const override;
+
+private:
+	Searcher* pEmployeeNumSearcher_;
+	Searcher* pNameSearcher_;
+	Searcher* pClSearcher_;
+	Searcher* pPhoneNumSearcher_;
+	Searcher* pBirthdaySearcher_;
+	Searcher* pCertiSearcher_;
+};
+
+////////////////////////////////////////
+//// Executor
+///////////////////////////////////////
+class Executor {
+public:
+	Executor(std::map<int, Employee>* pEmployees) : pEmployees_(pEmployees) {};
+	virtual ~Executor() {};
+	virtual std::map<int, Employee> execute(const std::map<int, Employee>* pSearchResult, const Option& option) = 0;
+
+protected:
+	std::map<int, Employee>* pEmployees_;
+};
+
+class AddExecutor : public Executor {
+public:
+	AddExecutor(std::map<int, Employee>* pEmployees) : Executor(pEmployees) {};
+	virtual std::map<int, Employee> execute(const std::map<int, Employee>* pSearchResult, const Option& option) override;
+};
+
+class DeleteExecutor : public Executor {
+public:
+	DeleteExecutor(std::map<int, Employee>* pEmployees) : Executor(pEmployees) {};
+	virtual std::map<int, Employee> execute(const std::map<int, Employee>* pSearchResult, const Option& option) override;
+};
+
+class ModifyExecutor : public Executor {
+public:
+	ModifyExecutor(std::map<int, Employee>* pEmployees) : Executor(pEmployees) {};
+	virtual std::map<int, Employee> execute(const std::map<int, Employee>* pSearchResult, const Option& option) override;
+};
+
+class IFactoryExecutor {
+public:
+	virtual ~IFactoryExecutor() {};
+	virtual Executor* getConcreteExecutor(const Option& option) = 0;
+};
+
+class FactoryExecutor : public IFactoryExecutor {
+public:
+	FactoryExecutor(std::map<int, Employee>* pEmployees);
+	~FactoryExecutor();
+	Executor* getConcreteExecutor(const Option& option) override;
+
+protected:
+	Executor* m_pAddExecutor_;
+	Executor* m_pDelExecutor_;
+	Executor* m_pModExecutor_;
+};
 
 class EmployeeManager {
 public:
+	EmployeeManager() : m_Employees(), m_Results() {
+		m_SearcherFactory = new FactorySearcher(&m_Employees);
+		m_ExecutorFactory = new FactoryExecutor(&m_Employees);
+	}
 	~EmployeeManager() {
 		m_Employees.clear();
 		m_Results.clear();
+
+		if (m_SearcherFactory) delete m_SearcherFactory;
+		if (m_ExecutorFactory) delete m_ExecutorFactory;
 	}
-
-	int GetEmployeeSize(void);
-	void Add(const Employee& employee);
-	void Modify(Employee& employee, std::string column, std::string value);
-
-	std::map<int, Employee> ModifyWithNoOption(std::string targetColumn, std::string targetValue, std::string changeColumn, std::string changeValue);
-	std::map<int, Employee> ModifyByFirstName(std::string targetColumn, std::string targetValue, std::string changeColumn, std::string changeValue);
-	std::map<int, Employee> ModifyByLastName(std::string targetColumn, std::string targetValue, std::string changeColumn, std::string changeValue);
-	std::map<int, Employee> ModifyByPhoneMidNumber(std::string targetColumn, std::string targetValue, std::string changeColumn, std::string changeValue);
-	std::map<int, Employee> ModifyByPhoneLastNumber(std::string targetColumn, std::string targetValue, std::string changeColumn, std::string changeValue);
-	std::map<int, Employee> ModifyByBirthYear(std::string targetColumn, std::string targetValue, std::string changeColumn, std::string changeValue);
-	std::map<int, Employee> ModifyByBirthMonth(std::string targetColumn, std::string targetValue, std::string changeColumn, std::string changeValue);
-	std::map<int, Employee> ModifyByBirthDay(std::string targetColumn, std::string targetValue, std::string changeColumn, std::string changeValue);
-	
-	std::map<int, Employee> DeleteWithNoOption(std::string column, std::string value);
-	std::map<int, Employee> DeleteByFirstName(std::string column, std::string value);
-	std::map<int, Employee> DeleteByLastName(std::string column, std::string value);
-	std::map<int, Employee> DeleteByPhoneMidNumber(std::string column, std::string value);
-	std::map<int, Employee> DeleteByPhoneLastNumber(std::string column, std::string value);
-	std::map<int, Employee> DeleteByBirthYear(std::string column, std::string value);
-	std::map<int, Employee> DeleteByBirthMonth(std::string column, std::string value);
-	std::map<int, Employee> DeleteByBirthDay(std::string column, std::string value);
-
-	std::map<int, Employee> SearchWithNoOption(std::string column, std::string value);
-	std::map<int, Employee> SearchByFirstName(std::string column, std::string value);
-	std::map<int, Employee> SearchByLastName(std::string column, std::string value);
-	std::map<int, Employee> SearchByPhoneMidNumber(std::string column, std::string value);
-	std::map<int, Employee> SearchByPhoneLastNumber(std::string column, std::string value);
-	std::map<int, Employee> SearchByBirthYear(std::string column, std::string value);
-	std::map<int, Employee> SearchByBirthMonth(std::string column, std::string value);
-	std::map<int, Employee> SearchByBirthDay(std::string column, std::string value);
+	std::map<int, Employee> search(const Option& option);
+	std::map<int, Employee> execute(const std::map<int, Employee>* searchRecords, const Option& option);
 
 private:
 	void clearResults() { m_Results.clear(); };
 
 	std::map<int, Employee> m_Employees;
 	std::map<int, Employee> m_Results;
+
+	IFactorySearcher* m_SearcherFactory;
+	IFactoryExecutor* m_ExecutorFactory;
 };

--- a/GCR Project/GCR Project.vcxproj
+++ b/GCR Project/GCR Project.vcxproj
@@ -146,6 +146,7 @@
     <ClInclude Include="Parser.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="common.cpp" />
     <ClCompile Include="EmployeeManager.cpp" />
     <ClCompile Include="File.cpp" />
     <ClCompile Include="main.cpp" />
@@ -154,6 +155,10 @@
   <ItemGroup>
     <Text Include="input_20_20.txt" />
     <Text Include="output_20_20.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="legay.puml" />
+    <None Include="refactoring_em.puml" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/GCR Project/GCR Project.vcxproj
+++ b/GCR Project/GCR Project.vcxproj
@@ -157,7 +157,7 @@
     <Text Include="output_20_20.txt" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="legay.puml" />
+    <None Include="legacy.puml" />
     <None Include="refactoring_em.puml" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/GCR Project/GCR Project.vcxproj.filters
+++ b/GCR Project/GCR Project.vcxproj.filters
@@ -44,6 +44,9 @@
     <ClCompile Include="Parser.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="common.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Text Include="input_20_20.txt">
@@ -52,5 +55,13 @@
     <Text Include="output_20_20.txt">
       <Filter>리소스 파일</Filter>
     </Text>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="legay.puml">
+      <Filter>리소스 파일</Filter>
+    </None>
+    <None Include="refactoring_em.puml">
+      <Filter>리소스 파일</Filter>
+    </None>
   </ItemGroup>
 </Project>

--- a/GCR Project/GCR Project.vcxproj.filters
+++ b/GCR Project/GCR Project.vcxproj.filters
@@ -57,7 +57,7 @@
     </Text>
   </ItemGroup>
   <ItemGroup>
-    <None Include="legay.puml">
+    <None Include="legacy.puml">
       <Filter>리소스 파일</Filter>
     </None>
     <None Include="refactoring_em.puml">

--- a/GCR Project/Parser.cpp
+++ b/GCR Project/Parser.cpp
@@ -1,65 +1,12 @@
 #include "Parser.h"
+#include "common.h"
+
 #include <vector>
 #include <sstream>
 #include <iostream>
 #include <map>
 
-#define NOOPTION 0
-#define FIRSTNAME 1
-#define LASTNAME 2
-#define MIDNUMBER 3
-#define LASTNUMBER 4
-#define YEAR 5
-#define MONTH 6
-#define DAY 7
-
 using namespace std;
-
-bool check_value_type(const string value) {
-	if (value[0] == '0')
-		return false;
-	else
-		return true;
-}
-
-int get_search_option(const string column, const string option) {
-	if (!option.compare("-f")) {
-		return FIRSTNAME;
-	}
-	else if (!option.compare("-l")) {
-		if (column == "name") return LASTNAME;
-		else return LASTNUMBER;
-	}
-	else if (!option.compare("-m")) {
-		if (column == "birthday") return MONTH;
-		else return MIDNUMBER;
-	}
-	else if (!option.compare("-y"))
-		return YEAR;
-	else if (!option.compare("-d"))
-		return DAY;
-	else
-		return NOOPTION;
-}
-
-bool check_print_option(const string option) {
-	if (!option.compare("-p"))
-		return true;
-	else
-		return false;
-}
-
-vector<string> p_splitString(const string& orgString, const char delimiter) {
-	vector<string> tokens;
-	istringstream strStream(orgString);
-	string token;
-
-	while (getline(strStream, token, delimiter)) {
-		tokens.push_back(token);
-	}
-
-	return tokens;
-}
 
 void Parser::request_add(const vector<string> tokens) {
 
@@ -70,140 +17,70 @@ void Parser::request_add(const vector<string> tokens) {
 	new_employee.Phone_number = tokens[7];
 	new_employee.BirthDay = tokens[8];
 	new_employee.Certi = tokens[9];
-	
-	employeemanager.Add(new_employee);
+
+	map<int, Employee> emptyResult;
+	employManager_.execute(&emptyResult, { COMMAND::ADD, OPTION1::NONE, OPTION2::NONE, new_employee, COLUMN::NONE, "", COLUMN::NONE, "" });
 }
 
 string Parser::request_del(const vector<string> tokens) {
 	string return_str;
-	string command = tokens[0];
 	map<int, Employee> recived_value;
-	bool print_option = check_print_option(tokens[1]);
-	string column = tokens[4];
-	int search_option = get_search_option(column, tokens[2]);
-	string value = tokens[5];
+	Option option;
 
+	fillOptionCommand(option, tokens[0]);
+	fillOption1(option, tokens[1]);
+	fillColumn(option, tokens[4], true);
+	fillOption2(option, tokens[2]);
+	fillSearchData(option, tokens[5]);
 
-	switch (search_option)
-	{
-	case NOOPTION:
-		recived_value = employeemanager.DeleteWithNoOption(column, value);
-		cout << recived_value.size() << endl;
-		break;
-	case FIRSTNAME:
-		recived_value = employeemanager.DeleteByFirstName(column, value);
-		break;
-	case LASTNAME:
-		recived_value = employeemanager.DeleteByLastName(column, value);
-		break;
-	case MIDNUMBER:
-		recived_value = employeemanager.DeleteByPhoneMidNumber(column, value);
-		break;
-	case LASTNUMBER:
-		recived_value = employeemanager.DeleteByPhoneLastNumber(column, value);
-		break;
-	case YEAR:
-		recived_value = employeemanager.DeleteByBirthYear(column, value);
-		break;
-	case MONTH:
-		recived_value = employeemanager.DeleteByBirthMonth(column, value);
-		break;
-	case DAY:
-		recived_value = employeemanager.DeleteByBirthDay(column, value);
-		break;
-	default:
-		break;
-	}
+	//search
+	recived_value = employManager_.search(option);
+
+	//execute with searched results
+	employManager_.execute(&recived_value, option);
 	
-	return_str = make_return_str(recived_value, command, print_option);
+	return_str = make_return_str(recived_value, option);
 	return return_str;
 }
 
 string Parser::request_search(const vector<string> tokens) {
 	string return_str;
-	string command = tokens[0];
 	map<int, Employee> recived_value;
-	bool print_option = check_print_option(tokens[1]);
-	string column = tokens[4];
-	int search_option = get_search_option(column, tokens[2]);
-	string value = tokens[5];
+	Option option;
 
-	switch (search_option)
-	{
-	case NOOPTION:
-		recived_value = employeemanager.SearchWithNoOption(column, value);
-		break;
-	case FIRSTNAME:
-		recived_value = employeemanager.SearchByFirstName(column, value);
-		break;
-	case LASTNAME:
-		recived_value = employeemanager.SearchByLastName(column, value);
-		break;
-	case MIDNUMBER:
-		recived_value = employeemanager.SearchByPhoneMidNumber(column, value);
-		break;
-	case LASTNUMBER:
-		recived_value = employeemanager.DeleteByPhoneLastNumber(column, value);
-		break;
-	case YEAR:
-		recived_value = employeemanager.SearchByBirthYear(column, value);
-		break;
-	case MONTH:
-		recived_value = employeemanager.SearchByBirthMonth(column, value);
-		break;
-	case DAY:
-		recived_value = employeemanager.SearchByBirthDay(column, value);
-		break;
-	default:
-		break;
-	}
+	fillOptionCommand(option, tokens[0]);
+	fillOption1(option, tokens[1]);
+	fillColumn(option, tokens[4], true);
+	fillOption2(option, tokens[2]);
+	fillSearchData(option, tokens[5]);
 
-	return_str = make_return_str(recived_value, command, print_option);
+	//search
+	recived_value = employManager_.search(option);
+
+	return_str = make_return_str(recived_value, option);
 	return return_str;
 }
 
 string Parser::request_mod(const vector<string> tokens) {
 	string return_str;
-	string command = tokens[0];
 	map<int, Employee> recived_value;
-	bool print_option = check_print_option(tokens[1]);
-	string search_column = tokens[4];
-	int search_option = get_search_option(search_column, tokens[2]);
-	string search_value = tokens[5];
-	string target_column = tokens[6];
-	string target_value = tokens[7];
 
-	switch (search_option)
-	{
-	case NOOPTION:
-		recived_value = employeemanager.ModifyWithNoOption(search_column, search_value,target_column,target_value);
-		break;
-	case FIRSTNAME:
-		recived_value = employeemanager.ModifyByFirstName(search_column, search_value,target_column,target_value);
-		break;
-	case LASTNAME:
-		recived_value = employeemanager.ModifyByLastName(search_column, search_value, target_column, target_value);
-		break;
-	case MIDNUMBER:
-		recived_value = employeemanager.ModifyByPhoneMidNumber(search_column, search_value,target_column,target_value);
-		break;
-	case LASTNUMBER:
-		recived_value = employeemanager.ModifyByPhoneLastNumber(search_column, search_value, target_column, target_value);
-		break;	
-	case YEAR:
-		recived_value = employeemanager.ModifyByBirthYear(search_column, search_value,target_column,target_value);
-		break;
-	case MONTH:
-		recived_value = employeemanager.ModifyByBirthMonth(search_column, search_value,target_column,target_value);
-		break;
-	case DAY:
-		recived_value = employeemanager.ModifyByBirthDay(search_column, search_value,target_column,target_value);
-		break;
-	default:
-		break;
-	}
+	Option option;
 
-	return_str = make_return_str(recived_value, command, print_option);
+	fillOptionCommand(option, tokens[0]);
+	fillOption1(option, tokens[1]);
+	fillColumn(option, tokens[4], true);
+	fillOption2(option, tokens[2]);
+	fillSearchData(option, tokens[5]);
+	fillColumn(option, tokens[6], false);
+	fillChangeData(option, tokens[7]);
+
+	//search
+	recived_value = employManager_.search(option);
+	//execute with searched results
+	employManager_.execute(&recived_value, option);
+	
+	return_str = make_return_str(recived_value, option);
 	return return_str;
 }
 
@@ -220,14 +97,15 @@ string Parser::request_management(const vector<string> tokens) {
 	return string();
 }
 
-string Parser::make_return_str(const map<int, Employee> recived_value, string command, bool print_option)
+string Parser::make_return_str(const map<int, Employee> recived_value, const Option& option)
 {
+	string cmdString = getStringFromOptionCommand(option);
 	if (recived_value.size() == 0) {
-		return command + ",NONE";
+		return cmdString + ",NONE";
 	}
 
-	if (!print_option) {
-		return command + "," + to_string(recived_value.size());
+	if (option.op1 == OPTION1::NONE) {
+		return cmdString + "," + to_string(recived_value.size());
 	}
 
 	string return_str;
@@ -235,7 +113,7 @@ string Parser::make_return_str(const map<int, Employee> recived_value, string co
 	for (auto iter = recived_value.begin(); iter != recived_value.end() && count < 5; iter++) {
 		if(iter != recived_value.begin())
 			return_str += "\n";
-		return_str += command + "," + (iter)->second.EmpNo + "," + (iter)->second.Name + "," + (iter)->second.Career_level + "," + (iter)->second.Phone_number + "," + (iter)->second.BirthDay + "," + (iter)->second.Certi;
+		return_str += cmdString + "," + (iter)->second.EmpNo + "," + (iter)->second.Name + "," + (iter)->second.Career_level + "," + (iter)->second.Phone_number + "," + (iter)->second.BirthDay + "," + (iter)->second.Certi;
 		count++;
 	}
 
@@ -246,7 +124,7 @@ string Parser::parse(const string input_txt)
 {
 	string return_str, recived_str;
 	
-	vector<string> tokens = p_splitString(input_txt, ',');
+	vector<string> tokens = stringTokenize(input_txt, ',');
 
 	recived_str = request_management(tokens);
 	

--- a/GCR Project/Parser.h
+++ b/GCR Project/Parser.h
@@ -7,16 +7,13 @@ using namespace std;
 
 class Parser{
 public:
-	Parser() {
-		employeemanager = EmployeeManager();
-	}
 	string request_management(const vector<string> tokens);
 	string request_del(const vector<string> tokens);
 	string request_search(const vector<string> tokens);
 	string request_mod(const vector<string> tokens);
-	string make_return_str(const map<int, Employee> recived_value, string command, bool print_option);
+	string make_return_str(const map<int, Employee> recived_value, const Option& option);
 	string parse(const string input_txt);
 	void request_add(const vector<string> tokens);
 private:
-	EmployeeManager employeemanager;
+	EmployeeManager employManager_;
 };

--- a/GCR Project/common.cpp
+++ b/GCR Project/common.cpp
@@ -1,0 +1,111 @@
+#include "common.h"
+
+#include <sstream>
+
+using namespace std;
+
+vector<string> stringTokenize(const std::string& orgString, const char delimiter) {
+	vector<string> tokens;
+	istringstream sstring(orgString);
+	string token;
+
+	while (getline(sstring, token, delimiter)) {
+		tokens.push_back(token);
+	}
+
+	return tokens;
+}
+
+void fillOptionCommand(Option& option, string token) {
+	if (token == "ADD") option.cmd = COMMAND::ADD;
+	else if (token == "DEL") option.cmd = COMMAND::DEL;
+	else if (token == "SCH") option.cmd = COMMAND::SCH;
+	else if (token == "MOD") option.cmd = COMMAND::MOD;
+	else throw runtime_error("ERROR:: invalid COMMAND!");
+}
+
+void fillOption1(Option& option, string token) {
+	if (token == "-p") option.op1 = OPTION1::P;
+	else option.op1 = OPTION1::NONE;
+}
+
+void fillOption2(Option& option, string token) {
+	if (token == "-f") {
+		option.op2 = OPTION2::FIRST_NAME;
+	}
+	else if (token == "-l") {
+		if (option.searchColumn == COLUMN::PHONENUM) option.op2 = OPTION2::LAST_NUMBER;
+		else if (option.searchColumn == COLUMN::NAME) option.op2 = OPTION2::LAST_NAME;
+		else throw runtime_error("ERROR:: no matching column type!!");
+	}
+	else if (token == "-m") {
+		if (option.searchColumn == COLUMN::PHONENUM) option.op2 = OPTION2::MID_NUMBER;
+		else if (option.searchColumn == COLUMN::BIRTHDAY) option.op2 = OPTION2::MONTH;
+		else throw runtime_error("ERROR:: no matching column type!!");
+	}
+	else if (token == "-y") {
+		option.op2 = OPTION2::YEAR;
+	}
+	else if (token == "-d") {
+		option.op2 = OPTION2::DAY;
+	}
+	else if (token == " ") {
+		option.op2 = OPTION2::NONE;
+	}
+	else {
+		throw runtime_error("ERROR:: invalid option string!!");
+	}
+}
+
+void fillColumn(Option& option, string token, bool isSearch) {
+	if (token == "employeeNum") {
+		if (isSearch) option.searchColumn = COLUMN::EMPLOYEENUM;
+		else option.changeColumn = COLUMN::EMPLOYEENUM;
+	}
+	else if (token == "name") {
+		if (isSearch) option.searchColumn = COLUMN::NAME;
+		else option.changeColumn = COLUMN::NAME;
+	}
+	else if (token == "cl") {
+		if (isSearch) option.searchColumn = COLUMN::CL;
+		else option.changeColumn = COLUMN::CL;
+	}
+	else if (token == "phoneNum") {
+		if (isSearch) option.searchColumn = COLUMN::PHONENUM;
+		else option.changeColumn = COLUMN::PHONENUM;
+	}
+	else if (token == "birthday") {
+		if (isSearch) option.searchColumn = COLUMN::BIRTHDAY;
+		else option.changeColumn = COLUMN::BIRTHDAY;
+	}
+	else if (token == "certi") {
+		if (isSearch) option.searchColumn = COLUMN::CERTI;
+		else option.changeColumn = COLUMN::CERTI;
+	}
+	else {
+		throw runtime_error("ERROD:: column token is invalid!!");
+	}
+}
+
+void fillSearchData(Option& option, string token) {
+	option.searchData = token;
+}
+
+void fillChangeData(Option& option, string token) {
+	option.changeData = token;
+}
+
+string getStringFromOptionCommand(const Option& option) {
+	switch (option.cmd) {
+	case COMMAND::ADD:
+		return "ADD";
+	case COMMAND::DEL:
+		return "DEL";
+	case COMMAND::SCH:
+		return "SCH";
+	case COMMAND::MOD:
+		return "MOD";
+	default:
+		throw runtime_error("ERROR:: NONE case could not hit here!");
+	}
+}

--- a/GCR Project/common.h
+++ b/GCR Project/common.h
@@ -1,4 +1,63 @@
 #pragma once
 #include <string>
 #include <iostream>
-using namespace std;
+#include <vector>
+
+#include "Employee.h"
+
+enum class OPTION1 {
+	NONE = 0, 
+	P,
+};
+
+enum class OPTION2 { 
+	NONE = 0,
+	FIRST_NAME,
+	LAST_NAME,
+	MID_NUMBER,
+	LAST_NUMBER,
+	YEAR, 
+	MONTH, 
+	DAY,
+};
+
+enum class COMMAND { 
+	NONE = 0,
+	ADD,
+	DEL,
+	SCH,
+	MOD
+};
+
+enum class COLUMN {
+	NONE = 0,
+	EMPLOYEENUM,
+	NAME,
+	CL,
+	PHONENUM,
+	BIRTHDAY,
+	CERTI,
+};
+
+struct Option {
+	COMMAND cmd;
+	OPTION1 op1;
+	OPTION2 op2;
+	//For ADD only
+	Employee employee;
+	//For DEL,SCH,MOD
+	COLUMN searchColumn;
+	std::string searchData;
+	//For MOD only
+	COLUMN changeColumn;
+	std::string changeData;	
+};
+
+std::vector<std::string> stringTokenize(const std::string & orgString, const char delimiter);
+void fillOptionCommand(Option& option, string token);
+void fillOption1(Option& option, string token);
+void fillOption2(Option& option, string token);
+void fillColumn(Option& option, string token, bool isSearch);
+void fillSearchData(Option& option, string token);
+void fillChangeData(Option& option, string token);
+string getStringFromOptionCommand(const Option& option);

--- a/GCR Project/legacy.puml
+++ b/GCR Project/legacy.puml
@@ -1,0 +1,74 @@
+﻿@startuml
+class File {
+-inFile_ : fstream
+-outFile_ : fstream 
+-inFileName_ : string
+-outFileName_ : string
++OpenFile(string, string) bool 
++ReadLine(void) : string 
++WriteLine(string) : void 
++CloseFile(void) : void 
++IsValidFiles(void) : bool
+}
+
+class Parser {
+-employeemanager : EmployeeManager
++equest_management(const vector<string>) : string 
++request_del(const vector<string>)  : string
++request_search(const vector<string>)  : string
++request_mod(const vector<string>)  : string
++make_return_str(const map<int, Employee>, string, bool)  : string
++parse(const string) : string
++request_add(const vector<string>) : void
+}
+
+class EmployeeManager {
+-m_Employees : map<int, Employee>
+-m_Results : map<int, Employee>
+-clearResults() : void
++GetEmployeeSize(void) : int 
++Add(const Employee& employee) : void
++Modify(Employee& employee, string, string) : void 
++ModifyWithNoOption(sting, string, string, string) : map<int, Employee> 
++ModifyByFirstName(sting, string, string, string) : map<int, Employee> 
++ModifyByLastName(sting, string, string, string) : map<int, Employee> 
++ModifyByPhoneMidNumber(sting, string, string, string) : map<int, Employee> 
++ModifyByPhoneLastNumber(sting, string, string, string) : map<int, Employee>  
++ModifyByBirthYear(sting, string, string, string) : map<int, Employee> 
++ModifyByBirthMonth(sting, string, string, string)  : map<int, Employee> 
++ModifyByBirthDay(sting, string, string, string) : map<int, Employee> 
++DeleteWithNoOption(sting, string) : map<int, Employee> 
++DeleteByFirstName(sting, string) : map<int, Employee> 
++DeleteByLastName(sting, string) : map<int, Employee> 
++DeleteByPhoneMidNumber(sting, string) : map<int, Employee> 
++DleteByPhoneLastNumber(sting, string) : map<int, Employee> 
++DeleteByBirthYear(sting, string) : map<int, Employee> 
++DeleteByBirthMonth(sting, string) : map<int, Employee> 
++DeleteByBirthDay(sting, string) : map<int, Employee> 
++SearchWithNoOption(sting, string) : map<int, Employee> 
++SearchByFirstName(sting, string) : map<int, Employee> 
++SearchByLastName(sting, string) : map<int, Employee> 
++SearchByPhoneMidNumber(sting, string) : map<int, Employee> 
++SearchByPhoneLastNumber(sting, string) : map<int, Employee> 
++SearchByBirthYear(sting, string) : map<int, Employee> 
++SearchByBirthMonth(sting, string) : map<int, Employee> 
++SearchByBirthDay(sting, string) : map<int, Employee> 
+}
+
+entity Employee {
++EmpNo : string 
++Name : string 
++Career_level : string 
++Phone_number : string 
++BirthDay : string 
++Certi : string 
+{static}makeKeyValueFromString(const string&) : int
+}
+circle main
+main --> File : <<use>>
+main --> Parser : <<use>>
+Parser --> EmployeeManager : <<use>>
+EmployeeManager o-- Employee
+Parser --> Employee : <<use>>
+
+@enduml

--- a/GCR Project/refactoring_em.puml
+++ b/GCR Project/refactoring_em.puml
@@ -1,0 +1,226 @@
+@startuml
+circle main
+
+class File {
+-inFile_ : fstream;
+-outFile_ : fstream;
+-inFileName_ : string;
+-outFileName_ : string;
++OpenFile(string, string) : bool;
++ReadLine(void) : string ;
++WriteLine(string) : void ; 
++CloseFile(void) : void ;
++IsValidFiles(void) : bool ;
+}
+
+class Parser {
+-employeemanager : EmployeeManager;
++request_management(const vector<string>) : string
++request_del(const vector<string>) : string
++request_search(const vector<string>) : string
++request_mod(const vector<string>) : string
++make_return_str(const map<int, Employee>, string, bool) : string
++parse(const string) : string
++request_add(const vector<string>) : void
+}
+
+class EmployeeManager {
+-m_Employees : map<int, Employee>
+-m_Results : map<int, Employee>
+-m_SearcherFactory : IFactorySearcher*
+-m_ExecutorFactory : IFactoryExecutor*
++search(const Option&) : map<int, Employee>
++execute(const map<int, Employee>*, const Option&) : map<int, Employee>
+}
+
+entity Employee {
++EmpNo : string
++Name : string
++Career_level : string
++Phone_number : string
++BirthDay : string
++Certi : string
+{static} int makeKeyValueFromString(const string&)
+}
+
+enum OPTION1 {
+NONE = 0
+P
+}
+
+enum OPTION2 {
+NONE = 0,
+FIRST_NAME,
+LAST_NAME,
+MID_NUMBER,
+LAST_NUMBER,
+YEAR, 
+MONTH, 
+DAY,
+}
+
+enum COMMAND {
+NONE = 0,
+ADD,
+DEL,
+SCH,
+MOD,
+}
+
+enum COLUMN {
+NONE = 0,
+EMPLOYEENUM,
+NAME,
+CL,
+PHONENUM,
+BIRTHDAY,
+CERTI,
+}
+
+entity Option {
++cmd : COMMAND
++op1 : OPTION1
++op2 : OPTION2
+..
++employee : Employee
+..
++searchColumn : COLUMN
++searchData : string
+..
++changeColumn : COLUMN
++changeData : string
+}
+note right of Option::"employee"
+	For ADD command	
+end note
+note right of Option::"searchColumn"
+	For DEL/SCH/MOD command	
+end note
+note right of Option::"changeColumn"
+	For MOD command	only
+end note
+
+interface IFactorySearcher {
++{abstract}~IFactorySearcher()
++{abstract}getConcreteSearcher(const Option& option) const : Searcher*
+}
+
+class FactorySearcher {
+-pEmpNumSearcher_ : Searcher*
+-pNameSearcher_ : Searcher*
+-pClSearcher_ : Searcher*
+-pPhoneNumberSearcher_ : Searcher*
+-pBirthdaySearcher_ : Searcher*
+-pCertiSearcher_ : Searcher*
++{abstract}getConcreteSearcher(const Option& option) const : Searcher*
+}
+
+IFactorySearcher <|-- FactorySearcher
+
+
+abstract class Searcher {
+#pEmployees_ : map<int, Employee>*
++Searcher(map<int, Employee>*)
++{abstract}~Searcher()
++{abstract}search(const Option& option) const : map<int, Employee>
+}
+
+class EmployeeNumSearcher {
++search(const Option& option) const : map<int, Employee>
+}
+
+class NameSearcher {
++search(const Option& option) const : map<int, Employee>
+}
+
+class ClSearcher {
++search(const Option& option) const : map<int, Employee>
+}
+
+class PhoneNumberSearcher {
++search(const Option& option) const : map<int, Employee>
+}
+
+class BirthdaySearcher {
++search(const Option& option) const : map<int, Employee>
+}
+
+class CertiSearcher {
++search(const Option& option) const : map<int, Employee>
+}
+
+EmployeeNumSearcher --|> Searcher
+NameSearcher --|> Searcher
+ClSearcher --|> Searcher
+PhoneNumberSearcher --|> Searcher
+BirthdaySearcher --|> Searcher
+CertiSearcher --|> Searcher
+
+FactorySearcher .left.> EmployeeNumSearcher : <<use>>
+FactorySearcher .left.> NameSearcher : <<use>>
+FactorySearcher .right.> ClSearcher : <<use>>
+FactorySearcher .right.> PhoneNumberSearcher : <<use>>
+FactorySearcher .down.> BirthdaySearcher : <<use>>
+FactorySearcher .down.> CertiSearcher : <<use>>
+
+interface IFactoryExecutor {
++{abstract}~IFactoryExecutor()
++{abstract}getConcreteExecutor(const Option& option) : Executor*
+}
+
+class FactoryExecutor {
++m_pAddExecutor_ : Executor*
++m_pDelExecutor_ : Executor*
++m_pModExecutor_ : Executor*
++getConcreteExecutor(const Option& option) : Executor*
+}
+
+IFactoryExecutor <|-- FactoryExecutor
+
+abstract class Executor {
+#pEmployees_ : map<int, Employee>*
++{abstract}Executor(map<int, Employee>*) 
++{abstract}~Executor()
++{abstract}execute(const map<int, Employee>*, const Option&) : map<int, Employee>
+}
+
+class AddExecutor {
++AddExecutor(map<int, Employee>*)
++execute(const map<int, Employee>*, const Option&) : map<int, Employee>
+}
+
+class DeleteExecutor {
++DeleteExecutor(map<int, Employee>*)
++execute(const map<int, Employee>*, const Option&) : map<int, Employee>
+}
+
+class ModifyExecutor {
++ModifyExecutor(map<int, Employee>*)
++execute(const map<int, Employee>*, const Option&) : map<int, Employee>
+}
+
+AddExecutor --|> Executor
+DeleteExecutor --|> Executor
+ModifyExecutor --|> Executor
+
+FactoryExecutor .left.> AddExecutor : <<use>>
+FactoryExecutor .right.> DeleteExecutor : <<use>>
+FactoryExecutor .down.> ModifyExecutor: <<use>>
+
+main ..> File : <<use>>
+main ..> Parser : <<use>>
+
+Option "1"-->"1" OPTION1
+Option "1"-->"1" OPTION2 
+Option "1"-->"1" COMMAND 
+Option "1"-->"0..1" Employee
+Option "1"-->"2" COLUMN
+
+Parser ..> EmployeeManager : <<use>>
+Option <.. Parser : <<use>>
+Option <.. EmployeeManager : <<use>>
+EmployeeManager ..> IFactorySearcher : <<use>>
+EmployeeManager ..> IFactoryExecutor : <<use>>
+Employee --o EmployeeManager
+
+@enduml

--- a/UnitTest/EmployeeManager_Unittest2.cpp
+++ b/UnitTest/EmployeeManager_Unittest2.cpp
@@ -6,13 +6,27 @@
 using namespace std;
 
 void initEmployeeData(EmployeeManager& em) {
-	em.Add({ "85125741", "FBAH RTIJ", "CL1", "010-8900-1478", "19780228", "ADV" });
-	em.Add({ "08117441", "BMU MPOSXU", "CL3", "010-2703-3153", "20010215", "ADV" });
-	em.Add({ "10127115", "KBU MHU", "CL3", "010-3284-4054", "19660814", "ADV" });
-	em.Add({ "12117017", "LFIS JJIVL", "CL1", "010-7914-4067", "20120812", "PRO" });
-	em.Add({ "11125777", "TKOQKIS HC", "CL1", "010-6734-2289", "19991001", "PRO" });
-	em.Add({ "11109136", "QKAHCEX LTODDO", "CL4", "010-2627-8566", "19640130", "PRO" });
-	em.Add({ "05101762", "VCUHLE HMU", "CL4", "010-3988-9289", "20030819", "PRO" });
+	map<int, Employee> emptyResult;
+	Option option = { COMMAND::ADD, OPTION1::NONE, OPTION2::NONE, { "85125741", "FBAH RTIJ", "CL1", "010-8900-1478", "19780228", "ADV" }, COLUMN::NONE, string(), COLUMN::NONE, string()};	
+	em.execute(&emptyResult, option);
+
+	option.employee = { "08117441", "BMU MPOSXU", "CL3", "010-2703-3153", "20010215", "ADV" };
+	em.execute(&emptyResult, option);
+
+	option.employee = { "10127115", "KBU MHU", "CL3", "010-3284-4054", "19660814", "ADV" };
+	em.execute(&emptyResult, option);
+
+	option.employee = { "12117017", "LFIS JJIVL", "CL1", "010-7914-4067", "20120812", "PRO" };
+	em.execute(&emptyResult, option);
+
+	option.employee = { "11125777", "TKOQKIS HC", "CL1", "010-6734-2289", "19991001", "PRO" };
+	em.execute(&emptyResult, option);
+
+	option.employee = { "11109136", "QKAHCEX LTODDO", "CL4", "010-2627-8566", "19640130", "PRO" };
+	em.execute(&emptyResult, option);
+
+	option.employee = { "05101762", "VCUHLE HMU", "CL4", "010-3988-9289", "20030819", "PRO" };
+	em.execute(&emptyResult, option);
 }
 
 TEST(EmployeeManagerTest2, SearchNoOptionTest) {
@@ -21,24 +35,31 @@ TEST(EmployeeManagerTest2, SearchNoOptionTest) {
 
 	initEmployeeData(em);
 
+	Option option = { COMMAND::SCH, OPTION1::NONE, OPTION2::NONE, Employee(), COLUMN::EMPLOYEENUM, "11125777", COLUMN::NONE, string() };
+
 	//EmployeeNum search
-	results = em.SearchWithNoOption("employeeNum", "11125777");
+	results = em.search(option);
 	EXPECT_EQ(1, results.size());
 	results.clear();
 
 	//CL search
-	results = em.SearchWithNoOption("cl", "CL4");
+	option.searchColumn = COLUMN::CL;
+	option.searchData = "CL4";
+	results = em.search(option);
 	EXPECT_EQ(2, results.size());
 	results.clear();
 
 	//Add CL4
-	em.Add({ "20091154", "LFIS AEDLW", "CL4", "010-6681-1104", "20081113", "ADV" });
-	results = em.SearchWithNoOption("cl", "CL4");
+	Option option2 = { COMMAND::ADD, OPTION1::NONE, OPTION2::NONE, { "20091154", "LFIS AEDLW", "CL4", "010-6681-1104", "20081113", "ADV" }, COLUMN::NONE, string(), COLUMN::NONE, string() };
+	em.execute(&results, option2);
+	results = em.search(option);
 	EXPECT_EQ(3, results.size());
 	results.clear();
 
 	//Certi search
-	results = em.SearchWithNoOption("certi", "PRO");
+	option.searchColumn = COLUMN::CERTI;
+	option.searchData = "PRO";
+	results = em.search(option);
 	EXPECT_EQ(4, results.size());
 	results.clear();
 }
@@ -49,29 +70,34 @@ TEST(EmployeeManagerTest2, SearchFirstNameTest) {
 
 	initEmployeeData(em);
 
-	results = em.SearchByFirstName("name", "LFIS");
+	Option option = { COMMAND::SCH, OPTION1::NONE, OPTION2::FIRST_NAME, Employee(), COLUMN::NAME, "LFIS", COLUMN::NONE, string() };
+	results = em.search(option);
 	EXPECT_EQ(1, results.size());
 	results.clear();
 
-	//Add
-	em.Add({ "20091154", "LFIS AEDLW", "CL2", "010-6681-1104", "20081113", "ADV" });
-	results = em.SearchByFirstName("name", "LFIS");
+	//ADD 1 more first name with LFIS
+	Option option2 = { COMMAND::ADD, OPTION1::NONE, OPTION2::NONE, { "20091154", "LFIS AEDLW", "CL2", "010-6681-1104", "20081113", "ADV" }, COLUMN::NONE, string(), COLUMN::NONE, string() };
+	em.execute(&results, option2);
+
+	results = em.search(option);
 	EXPECT_EQ(2, results.size());
 	results.clear();
 
 	//Modify
-	em.ModifyByFirstName("name", "LFIS", "cl", "CL3");
-	results = em.SearchByFirstName("name", "LFIS");
+	Option option3 = { COMMAND::MOD, OPTION1::NONE, OPTION2::FIRST_NAME, Employee(), COLUMN::NAME, "LFIS", COLUMN::CL, "CL3" };
+	results = em.execute(&em.search(option3), option3);
 	EXPECT_EQ(2, results.size());
 	results.clear();
 
-	results = em.SearchByFirstName("name", "TKOQKIS");
+	option.searchData = "TKOQKIS";
+	results = em.search(option);
 	EXPECT_EQ(1, results.size());
 	results.clear();
 
 	//Delete
-	em.DeleteByFirstName("name", "TKOQKIS");
-	results = em.SearchByFirstName("name", "TKOQKIS");
+	Option option4 = { COMMAND::DEL, OPTION1::NONE, OPTION2::FIRST_NAME, Employee(), COLUMN::NAME, "TKOQKIS", COLUMN::NONE, string() };
+	em.execute(&em.search(option4), option4);
+	results = em.search(option);
 	EXPECT_EQ(0, results.size());
 	results.clear();
 }
@@ -82,33 +108,37 @@ TEST(EmployeeManagerTest2, SearchLastNameTest) {
 
 	initEmployeeData(em);
 
-	results = em.SearchByLastName("name", "MPOSXU");
+	Option option = { COMMAND::SCH, OPTION1::NONE, OPTION2::LAST_NAME, Employee(), COLUMN::NAME, "MPOSXU", COLUMN::NONE, string() };
+	results = em.search(option);
 	EXPECT_EQ(1, results.size());
 	results.clear();
 
 	//Add
-	em.Add({ "20091154", "QKAHCEX MPOSXU", "CL4", "010-1978-6651", "20100111", "PRO" });
-	results = em.SearchByLastName("name", "MPOSXU");
+	Option option2 = { COMMAND::ADD, OPTION1::NONE, OPTION2::NONE, { "20091154", "QKAHCEX MPOSXU", "CL4", "010-1978-6651", "20100111", "PRO" }, COLUMN::NONE, string(), COLUMN::NONE, string() };
+	em.execute(&results, option2);
+
+	results = em.search(option);
 	EXPECT_EQ(2, results.size());
 	results.clear();
 
 	//Modify
-	em.ModifyByLastName("name", "MPOSXU", "cl", "CL4");
-	results = em.SearchByLastName("name", "MPOSXU");
+	Option option3 = { COMMAND::MOD, OPTION1::NONE, OPTION2::LAST_NAME, Employee(), COLUMN::NAME, "MPOSXU", COLUMN::CL, "CL4" };
+	results = em.execute(&em.search(option3), option3);
+
+	results = em.search(option);
 	EXPECT_EQ(2, results.size());
 	results.clear();
 
-	results = em.SearchByLastName("name", "MPOSXU");
-	EXPECT_EQ(2, results.size());
-	results.clear();
-
-	results = em.SearchByLastName("name", "RTIJ");
+	option.searchData = "RTIJ";
+	results = em.search(option);
 	EXPECT_EQ(1, results.size());
 	results.clear();
 
 	//Delete
-	em.DeleteByLastName("name", "RTIJ");
-	results = em.SearchByLastName("name", "RTIJ");
+	Option option4 = { COMMAND::DEL, OPTION1::NONE, OPTION2::LAST_NAME, Employee(), COLUMN::NAME, "RTIJ", COLUMN::NONE, string() };
+	em.execute(&em.search(option4), option4);
+
+	results = em.search(option);
 	EXPECT_EQ(0, results.size());
 	results.clear();
 }
@@ -119,25 +149,32 @@ TEST(EmployeeManagerTest2, SearchPhoneMiddleNumberTest) {
 
 	initEmployeeData(em);
 
-	results = em.SearchByPhoneMidNumber("phone_number", "7914");
+	Option option = { COMMAND::SCH, OPTION1::NONE, OPTION2::MID_NUMBER, Employee(), COLUMN::PHONENUM, "7914", COLUMN::NONE, string() };
+	results = em.search(option);
 	EXPECT_EQ(1, results.size());
 	results.clear();
 
 	//Add
-	em.Add({ "20091154", "LFIS AEDLW", "CL2", "010-7914-2808", "20110925", "PRO" });
-	results = em.SearchByPhoneMidNumber("phone_number", "7914");
+	Option option2 = { COMMAND::ADD, OPTION1::NONE, OPTION2::NONE, { "20091154", "LFIS AEDLW", "CL2", "010-7914-2808", "20110925", "PRO" }, COLUMN::NONE, string(), COLUMN::NONE, string() };
+	em.execute(&results, option2);
+
+	results = em.search(option);
 	EXPECT_EQ(2, results.size());
 	results.clear();
 
 	//Modify
-	em.ModifyByPhoneMidNumber("phone_number", "7914", "certi", "ADV");
-	results = em.SearchByPhoneMidNumber("phone_number", "7914");
+	Option option3 = { COMMAND::MOD, OPTION1::NONE, OPTION2::MID_NUMBER, Employee(), COLUMN::PHONENUM, "7914", COLUMN::CERTI, "ADV" };
+	results = em.execute(&em.search(option3), option3);
+
+	results = em.search(option);
 	EXPECT_EQ(2, results.size());
 	results.clear();
 
 	//Delete
-	em.DeleteByPhoneMidNumber("phone_number", "7914");
-	results = em.SearchByPhoneMidNumber("phone_number", "7914");
+	Option option4 = { COMMAND::DEL, OPTION1::NONE, OPTION2::MID_NUMBER, Employee(), COLUMN::PHONENUM, "7914", COLUMN::NONE, string() };
+	em.execute(&em.search(option4), option4);
+
+	results = em.search(option);
 	EXPECT_EQ(0, results.size());
 	results.clear();
 }
@@ -148,25 +185,32 @@ TEST(EmployeeManagerTest2, SearchPhoneLastNumberTest) {
 
 	initEmployeeData(em);
 
-	results = em.SearchByPhoneLastNumber("phone_number", "8566");
+	Option option = { COMMAND::SCH, OPTION1::NONE, OPTION2::LAST_NUMBER, Employee(), COLUMN::PHONENUM, "8566", COLUMN::NONE, string() };
+	results = em.search(option);
 	EXPECT_EQ(1, results.size());
 	results.clear();
 
 	//Add
-	em.Add({ "20091154", "LFIS AEDLW", "CL2", "010-7914-8566", "20110925", "PRO" });
-	results = em.SearchByPhoneLastNumber("phone_number", "8566");
+	Option option2 = { COMMAND::ADD, OPTION1::NONE, OPTION2::NONE, { "20091154", "LFIS AEDLW", "CL2", "010-7914-8566", "20110925", "PRO" }, COLUMN::NONE, string(), COLUMN::NONE, string() };
+	em.execute(&results, option2);
+
+	results = em.search(option);
 	EXPECT_EQ(2, results.size());
 	results.clear();
 
 	//Modify
-	em.ModifyByPhoneLastNumber("phone_number", "8566", "certi", "ADV");
-	results = em.SearchByPhoneLastNumber("phone_number", "8566");
+	Option option3 = { COMMAND::MOD, OPTION1::NONE, OPTION2::LAST_NUMBER, Employee(), COLUMN::PHONENUM, "8566", COLUMN::CERTI, "ADV" };
+	results = em.execute(&em.search(option3), option3);
+
+	results = em.search(option);
 	EXPECT_EQ(2, results.size());
 	results.clear();
 
 	//Delete
-	em.DeleteByPhoneLastNumber("phone_number", "8566");
-	results = em.SearchByPhoneLastNumber("phone_number", "8566");
+	Option option4 = { COMMAND::DEL, OPTION1::NONE, OPTION2::LAST_NUMBER, Employee(), COLUMN::PHONENUM, "8566", COLUMN::NONE, string() };
+	em.execute(&em.search(option4), option4);
+
+	results = em.search(option);
 	EXPECT_EQ(0, results.size());
 	results.clear();
 }
@@ -177,25 +221,32 @@ TEST(EmployeeManagerTest2, SearchBirthYearTest) {
 
 	initEmployeeData(em);
 
-	results = em.SearchByBirthYear("birthday", "2012");
+	Option option = { COMMAND::SCH, OPTION1::NONE, OPTION2::YEAR, Employee(), COLUMN::BIRTHDAY, "2012", COLUMN::NONE, string() };
+	results = em.search(option);
 	EXPECT_EQ(1, results.size());
 	results.clear();
 
 	//Add
-	em.Add({ "20091154", "LFIS AEDLW", "CL2", "010-7914-8566", "20120925", "PRO" });
-	results = em.SearchByBirthYear("birthday", "2012");
+	Option option2 = { COMMAND::ADD, OPTION1::NONE, OPTION2::NONE, { "20091154", "LFIS AEDLW", "CL2", "010-7914-8566", "20120925", "PRO" }, COLUMN::NONE, string(), COLUMN::NONE, string() };
+	em.execute(&results, option2);
+
+	results = em.search(option);
 	EXPECT_EQ(2, results.size());
 	results.clear();
 
 	//Modify
-	em.ModifyByBirthYear("birthday", "2012", "name", "ERGY DFEH");
-	results = em.SearchByBirthYear("birthday", "2012");
+	Option option3 = { COMMAND::MOD, OPTION1::NONE, OPTION2::YEAR, Employee(), COLUMN::BIRTHDAY, "2012", COLUMN::NAME, "ERGY DFEH" };
+	results = em.execute(&em.search(option3), option3);
+
+	results = em.search(option);
 	EXPECT_EQ(2, results.size());
 	results.clear();
 
 	//Delete
-	em.DeleteByBirthYear("birthday", "2012");
-	results = em.SearchByBirthYear("birthday", "2012");
+	Option option4 = { COMMAND::DEL, OPTION1::NONE, OPTION2::YEAR, Employee(), COLUMN::BIRTHDAY, "2012", COLUMN::NONE, string() };
+	em.execute(&em.search(option4), option4);
+
+	results = em.search(option);
 	EXPECT_EQ(0, results.size());
 	results.clear();
 }
@@ -206,29 +257,37 @@ TEST(EmployeeManagerTest2, SearchBirthMonthTest) {
 
 	initEmployeeData(em);
 
-	results = em.SearchByBirthMonth("birthday", "02");
+	Option option = { COMMAND::SCH, OPTION1::NONE, OPTION2::MONTH, Employee(), COLUMN::BIRTHDAY, "02", COLUMN::NONE, string() };
+	results = em.search(option);
 	EXPECT_EQ(2, results.size());
 	results.clear();
 
 	//Add
-	em.Add({ "20091154", "LFIS AEDLW", "CL2", "010-7914-8566", "20120225", "PRO" });
-	results = em.SearchByBirthMonth("birthday", "02");
+	Option option2 = { COMMAND::ADD, OPTION1::NONE, OPTION2::NONE, { "20091154", "LFIS AEDLW", "CL2", "010-7914-8566", "20120225", "PRO" }, COLUMN::NONE, string(), COLUMN::NONE, string() };
+	em.execute(&results, option2);
+
+	results = em.search(option);
 	EXPECT_EQ(3, results.size());
 	results.clear();
 
 	//Modify
-	em.ModifyByBirthMonth("birthday", "02", "name", "QWRY DHUJ");
-	results = em.SearchByBirthMonth("birthday", "02");
+	Option option3 = { COMMAND::MOD, OPTION1::NONE, OPTION2::MONTH, Employee(), COLUMN::BIRTHDAY, "02", COLUMN::NAME, "QWRY DHUJ" };
+	results = em.execute(&em.search(option3), option3);
+
+	results = em.search(option);
 	EXPECT_EQ(3, results.size());
 	results.clear();
 
-	results = em.SearchByBirthMonth("birthday", "08");
+	option.searchData = "08";
+	results = em.search(option);
 	EXPECT_EQ(3, results.size());
 	results.clear();
 
 	//Delete
-	em.DeleteByBirthMonth("birthday", "08");
-	results = em.SearchByBirthMonth("birthday", "08");
+	Option option4 = { COMMAND::DEL, OPTION1::NONE, OPTION2::MONTH, Employee(), COLUMN::BIRTHDAY, "08", COLUMN::NONE, string() };
+	em.execute(&em.search(option4), option4);
+
+	results = em.search(option);
 	EXPECT_EQ(0, results.size());
 	results.clear();
 }
@@ -239,29 +298,37 @@ TEST(EmployeeManagerTest2, SearchBirthDayTest) {
 
 	initEmployeeData(em);
 
-	results = em.SearchByBirthDay("birthday", "15");
+	Option option = { COMMAND::SCH, OPTION1::NONE, OPTION2::DAY, Employee(), COLUMN::BIRTHDAY, "15", COLUMN::NONE, string() };
+	results = em.search(option);
 	EXPECT_EQ(1, results.size());
 	results.clear();
 
 	//Add
-	em.Add({ "20091154", "LFIS AEDLW", "CL2", "010-7914-8566", "20120215", "PRO" });
-	results = em.SearchByBirthDay("birthday", "15");
+	Option option2 = { COMMAND::ADD, OPTION1::NONE, OPTION2::NONE, { "20091154", "LFIS AEDLW", "CL2", "010-7914-8566", "20120215", "PRO" }, COLUMN::NONE, string(), COLUMN::NONE, string() };
+	em.execute(&results, option2);
+
+	results = em.search(option);
 	EXPECT_EQ(2, results.size());
 	results.clear();
 
 	//Modify
-	em.ModifyByBirthDay("birthday", "15", "cl", "CL2");
-	results = em.SearchByBirthDay("birthday", "15");
+	Option option3 = { COMMAND::MOD, OPTION1::NONE, OPTION2::DAY, Employee(), COLUMN::BIRTHDAY, "15", COLUMN::CL, "CL2" };
+	results = em.execute(&em.search(option3), option3);
+
+	results = em.search(option);
 	EXPECT_EQ(2, results.size());
 	results.clear();
 
-	results = em.SearchByBirthDay("birthday", "12");
+	option.searchData = "12";
+	results = em.search(option);
 	EXPECT_EQ(1, results.size());
 	results.clear();
 
 	//Delete
-	em.DeleteByBirthDay("birthday", "12");
-	results = em.SearchByBirthDay("birthday", "12");
+	Option option4 = { COMMAND::DEL, OPTION1::NONE, OPTION2::DAY, Employee(), COLUMN::BIRTHDAY, "12", COLUMN::NONE, string() };
+	em.execute(&em.search(option4), option4);
+
+	results = em.search(option);
 	EXPECT_EQ(0, results.size());
 	results.clear();
 }
@@ -274,29 +341,33 @@ TEST(EmployeeManagerTest2, DeleteNoOptionTest) {
 	initEmployeeData(em);
 
 	//EmployeeNum delete
-	searchResults = em.SearchWithNoOption("employeeNum", "10127115");
-	deleteResults = em.DeleteWithNoOption("employeeNum", "10127115");
-
+	Option option = { COMMAND::SCH, OPTION1::NONE, OPTION2::NONE, Employee(), COLUMN::EMPLOYEENUM, "10127115", COLUMN::NONE, string() };
+	searchResults = em.search(option);
+	option.cmd = COMMAND::DEL;
+	deleteResults = em.execute(&searchResults, option);
 	EXPECT_EQ(deleteResults.size(), searchResults.size());
-
 	searchResults.clear();
 	deleteResults.clear();
 
 	//CL delete
-	searchResults = em.SearchWithNoOption("cl", "CL3");
-	deleteResults = em.DeleteWithNoOption("cl", "CL3");
-
+	option.cmd = COMMAND::SCH;
+	option.searchColumn = COLUMN::CL;
+	option.searchData = "CL3";
+	searchResults = em.search(option);
+	option.cmd = COMMAND::DEL;
+	deleteResults = em.execute(&searchResults, option);
 	EXPECT_EQ(deleteResults.size(), searchResults.size());
-
 	searchResults.clear();
 	deleteResults.clear();
 
 	//Certi delete
-	searchResults = em.SearchWithNoOption("certi", "PRO");
-	deleteResults = em.DeleteWithNoOption("certi", "PRO");
-
+	option.cmd = COMMAND::SCH;
+	option.searchColumn = COLUMN::CERTI;
+	option.searchData = "PRO";
+	searchResults = em.search(option);
+	option.cmd = COMMAND::DEL;
+	deleteResults = em.execute(&searchResults, option);
 	EXPECT_EQ(deleteResults.size(), searchResults.size());
-
 	searchResults.clear();
 	deleteResults.clear();
 }
@@ -308,11 +379,11 @@ TEST(EmployeeManagerTest2, DeleteFirstNameTest) {
 
 	initEmployeeData(em);
 
-	searchResults = em.SearchByFirstName("name", "LFIS");
-	deleteResults = em.DeleteByFirstName("name", "LFIS");
-
+	Option option = { COMMAND::SCH, OPTION1::NONE, OPTION2::FIRST_NAME, Employee(), COLUMN::NAME, "LFIS", COLUMN::NONE, string() };
+	searchResults = em.search(option);
+	option.cmd = COMMAND::DEL;
+	deleteResults = em.execute(&searchResults, option);
 	EXPECT_EQ(deleteResults.size(), searchResults.size());
-	
 	searchResults.clear();
 	deleteResults.clear();	
 }
@@ -324,11 +395,11 @@ TEST(EmployeeManagerTest2, DeleteLastNameTest) {
 
 	initEmployeeData(em);
 
-	searchResults = em.SearchByLastName("name", "LTODDO");
-	deleteResults = em.DeleteByLastName("name", "LTODDO");
-
+	Option option = { COMMAND::SCH, OPTION1::NONE, OPTION2::LAST_NAME, Employee(), COLUMN::NAME, "LTODDO", COLUMN::NONE, string() };
+	searchResults = em.search(option);
+	option.cmd = COMMAND::DEL;
+	deleteResults = em.execute(&searchResults, option);
 	EXPECT_EQ(deleteResults.size(), searchResults.size());
-
 	searchResults.clear();
 	deleteResults.clear();
 }
@@ -340,11 +411,12 @@ TEST(EmployeeManagerTest2, DeletePhoneMidNumberTest) {
 
 	initEmployeeData(em);
 
-	searchResults = em.SearchByPhoneMidNumber("phone_number", "7914");
-	deleteResults = em.DeleteByPhoneMidNumber("phone_number", "7914");
-
+	Option option = { COMMAND::SCH, OPTION1::NONE, OPTION2::MID_NUMBER, Employee(), COLUMN::PHONENUM, "7914", COLUMN::NONE, string() };
+	searchResults = em.search(option);
+	option.cmd = COMMAND::DEL;
+	deleteResults = em.execute(&searchResults, option);
 	EXPECT_EQ(deleteResults.size(), searchResults.size());
-
+	EXPECT_EQ(deleteResults.size(), searchResults.size());
 	searchResults.clear();
 	deleteResults.clear();
 }
@@ -356,11 +428,12 @@ TEST(EmployeeManagerTest2, DeletePhoneLastNumberTest) {
 
 	initEmployeeData(em);
 
-	searchResults = em.SearchByPhoneLastNumber("phone_number", "4054");
-	deleteResults = em.DeleteByPhoneLastNumber("phone_number", "4054");
-
+	Option option = { COMMAND::SCH, OPTION1::NONE, OPTION2::LAST_NUMBER, Employee(), COLUMN::PHONENUM, "4054", COLUMN::NONE, string() };
+	searchResults = em.search(option);
+	option.cmd = COMMAND::DEL;
+	deleteResults = em.execute(&searchResults, option);
 	EXPECT_EQ(deleteResults.size(), searchResults.size());
-
+	EXPECT_EQ(deleteResults.size(), searchResults.size());
 	searchResults.clear();
 	deleteResults.clear();
 }
@@ -372,11 +445,12 @@ TEST(EmployeeManagerTest2, DeleteBirthYearTest) {
 
 	initEmployeeData(em);
 
-	searchResults = em.SearchByBirthYear("birthday", "1966");
-	deleteResults = em.DeleteByBirthYear("birthday", "1966");
-
+	Option option = { COMMAND::SCH, OPTION1::NONE, OPTION2::YEAR, Employee(), COLUMN::BIRTHDAY, "1966", COLUMN::NONE, string() };
+	searchResults = em.search(option);
+	option.cmd = COMMAND::DEL;
+	deleteResults = em.execute(&searchResults, option);
 	EXPECT_EQ(deleteResults.size(), searchResults.size());
-
+	EXPECT_EQ(deleteResults.size(), searchResults.size());
 	searchResults.clear();
 	deleteResults.clear();
 }
@@ -388,11 +462,12 @@ TEST(EmployeeManagerTest2, DeleteBirthMonthTest) {
 
 	initEmployeeData(em);
 
-	searchResults = em.SearchByBirthMonth("birthday", "02");
-	deleteResults = em.DeleteByBirthMonth("birthday", "02");
-
+	Option option = { COMMAND::SCH, OPTION1::NONE, OPTION2::MONTH, Employee(), COLUMN::BIRTHDAY, "02", COLUMN::NONE, string() };
+	searchResults = em.search(option);
+	option.cmd = COMMAND::DEL;
+	deleteResults = em.execute(&searchResults, option);
 	EXPECT_EQ(deleteResults.size(), searchResults.size());
-
+	EXPECT_EQ(deleteResults.size(), searchResults.size());
 	searchResults.clear();
 	deleteResults.clear();
 }
@@ -404,11 +479,12 @@ TEST(EmployeeManagerTest2, DeleteBirthDayTest) {
 
 	initEmployeeData(em);
 
-	searchResults = em.SearchByBirthDay("birthday", "30");
-	deleteResults = em.DeleteByBirthDay("birthday", "30");
-
+	Option option = { COMMAND::SCH, OPTION1::NONE, OPTION2::DAY, Employee(), COLUMN::BIRTHDAY, "30", COLUMN::NONE, string() };
+	searchResults = em.search(option);
+	option.cmd = COMMAND::DEL;
+	deleteResults = em.execute(&searchResults, option);
 	EXPECT_EQ(deleteResults.size(), searchResults.size());
-
+	EXPECT_EQ(deleteResults.size(), searchResults.size());
 	searchResults.clear();
 	deleteResults.clear();
 }

--- a/UnitTest/EmployeeManager_unittest_hm.cpp
+++ b/UnitTest/EmployeeManager_unittest_hm.cpp
@@ -2,22 +2,48 @@
 #include "../GCR Project/EmployeeManager.h"
 #include "../GCR Project/EmployeeManager.cpp"
 
+using namespace std;
 
 void initEmployManager(EmployeeManager& employeeManager) {
-	employeeManager.Add({ "13009524", "Hyeonmin Seo", "CL3", "010-8463-5536", "19870319", "PRO" });
-	employeeManager.Add({ "13009500", "Hyeonmia Seo", "CL1", "010-8463-5516", "19881129", "ADV" });
-	employeeManager.Add({ "13009521", "Hyeonmib Eeo", "CL2", "010-8463-5526", "19890130", "EXP" });
-	employeeManager.Add({ "13009522", "Hyeonmic Leo", "CL3", "010-8443-5536", "19810719", "PRO" });
-	employeeManager.Add({ "13009523", "Hyeonmid Aeo", "CL4", "010-8453-5536", "19820911", "ADV" });
+	map<int, Employee> emptyResult;
+	Option option = { COMMAND::ADD, OPTION1::NONE, OPTION2::NONE, { "85125741", "FBAH RTIJ", "CL1", "010-8900-1478", "19780228", "ADV" }, COLUMN::NONE, string(), COLUMN::NONE, string() };
+	employeeManager.execute(&emptyResult, option);
+
+	option.employee = { "13009524", "Hyeonmin Seo", "CL3", "010-8463-5536", "19870319", "PRO" };
+	employeeManager.execute(&emptyResult, option);
+
+	option.employee = { "13009500", "Hyeonmia Seo", "CL1", "010-8463-5516", "19881129", "ADV" };
+	employeeManager.execute(&emptyResult, option);
+
+	option.employee = { "13009521", "Hyeonmib Eeo", "CL2", "010-8463-5526", "19890130", "EXP" };
+	employeeManager.execute(&emptyResult, option);
+
+	option.employee = { "13009522", "Hyeonmic Leo", "CL3", "010-8443-5536", "19810719", "PRO" };
+	employeeManager.execute(&emptyResult, option);
+
+	option.employee = { "13009523", "Hyeonmid Aeo", "CL4", "010-8453-5536", "19820911", "ADV" };
+	employeeManager.execute(&emptyResult, option);
 }
 
 TEST(EmployeeManagerHMTest, AddTest) {
 	EmployeeManager employeeManager;
-	EXPECT_EQ(0, employeeManager.GetEmployeeSize());	
-	employeeManager.Add({ "13009524", "Hyeonmin Seo", "CL3", "010-8463-5536", "19870319", "PRO" });
-	EXPECT_EQ(1, employeeManager.GetEmployeeSize());
-	employeeManager.Add({ "13009521", "Hyeonmib Eeo", "CL2", "010-8463-5526", "19890130", "EXP" });	
-	EXPECT_EQ(2, employeeManager.GetEmployeeSize());
+	map<int, Employee> results;
+
+	Option option = { COMMAND::ADD, OPTION1::NONE, OPTION2::NONE, { "13009524", "Hyeonmin Seo", "CL3", "010-8463-5536", "19870319", "PRO" }, COLUMN::NONE, string(), COLUMN::NONE, string() };
+	employeeManager.execute(&results, option);
+
+	Option option2 = { COMMAND::SCH, OPTION1::NONE, OPTION2::NONE, Employee(), COLUMN::EMPLOYEENUM, "13009524", COLUMN::NONE, string() };
+	results = employeeManager.search(option2);
+	EXPECT_EQ(1, results.size());
+	results.clear();
+	
+	option.employee = { "13009521", "Hyeonmib Eeo", "CL2", "010-8463-5526", "19890130", "EXP" };
+	employeeManager.execute(&results, option);
+	
+	option2.searchData = "13009521";
+	results = employeeManager.search(option2);
+	EXPECT_EQ(1, results.size());
+	results.clear();	
 }
 
 TEST(EmployeeManagerHMTest, ModifyByFirstNameTest) 
@@ -26,11 +52,14 @@ TEST(EmployeeManagerHMTest, ModifyByFirstNameTest)
 	initEmployManager(employeeManager);
 	
 	std::map<int, Employee> result;
-	
-	employeeManager.ModifyByFirstName("FirstName", "Hyeonmin", "phoneNum", "010-8463-5516");
-	result = employeeManager.SearchByPhoneLastNumber("", "5516");
-	EXPECT_EQ(2, result.size());
 
+	Option option1 = { COMMAND::MOD, OPTION1::NONE, OPTION2::FIRST_NAME, Employee(), COLUMN::NAME, "Hyeonmin", COLUMN::PHONENUM, "010-8463-5516" };
+	result = employeeManager.execute(&employeeManager.search(option1), option1);
+	result.clear();
+	
+	Option option2 = { COMMAND::SCH, OPTION1::NONE, OPTION2::LAST_NUMBER, Employee(), COLUMN::PHONENUM, "5516", COLUMN::NONE, string() };
+	result = employeeManager.search(option2);
+	EXPECT_EQ(2, result.size());
 }
 
 TEST(EmployeeManagerHMTest, ModifyByLastNameTest) 
@@ -40,9 +69,12 @@ TEST(EmployeeManagerHMTest, ModifyByLastNameTest)
 
 	std::map<int, Employee> result;
 
-	employeeManager.ModifyByLastName("LastName", "Seo", "cl", "CL4");
-	result = employeeManager.SearchWithNoOption("cl", "CL4");
-
+	Option option1 = { COMMAND::MOD, OPTION1::NONE, OPTION2::LAST_NAME, Employee(), COLUMN::NAME, "Seo", COLUMN::CL, "CL4" };
+	result = employeeManager.execute(&employeeManager.search(option1), option1);
+	result.clear();
+	
+	Option option2 = { COMMAND::SCH, OPTION1::NONE, OPTION2::NONE, Employee(), COLUMN::CL, "CL4", COLUMN::NONE, string() };
+	result = employeeManager.search(option2);
 	EXPECT_EQ(3, result.size());
 }
 
@@ -53,9 +85,12 @@ TEST(EmployeeManagerHMTest, ModifyByPhoneMidNumberTest)
 
 	std::map<int, Employee> result;
 
-	employeeManager.ModifyByPhoneMidNumber("PhoneMidNumber", "8443", "birthday", "19691130");
-	result = employeeManager.SearchByBirthDay("birthday", "30");
-	
+	Option option1 = { COMMAND::MOD, OPTION1::NONE, OPTION2::MID_NUMBER, Employee(), COLUMN::PHONENUM, "8443", COLUMN::BIRTHDAY, "19691130" };
+	result = employeeManager.execute(&employeeManager.search(option1), option1);
+	result.clear();
+
+	Option option2 = { COMMAND::SCH, OPTION1::NONE, OPTION2::DAY, Employee(), COLUMN::BIRTHDAY, "30", COLUMN::NONE, string() };
+	result = employeeManager.search(option2);
 	EXPECT_EQ(2, result.size());
 }
 
@@ -66,8 +101,12 @@ TEST(EmployeeManagerHMTest, ModifyByPhoneLastNumberTest)
 
 	std::map<int, Employee> result;
 
-	employeeManager.ModifyByPhoneLastNumber("PhoneLastNumber", "5516", "birthday", "19900420");
-	result = employeeManager.SearchByBirthYear("BirthYear", "1990");
+	Option option1 = { COMMAND::MOD, OPTION1::NONE, OPTION2::LAST_NUMBER, Employee(), COLUMN::PHONENUM, "5516", COLUMN::BIRTHDAY, "19900420" };
+	result = employeeManager.execute(&employeeManager.search(option1), option1);
+	result.clear();
+
+	Option option2 = { COMMAND::SCH, OPTION1::NONE, OPTION2::YEAR, Employee(), COLUMN::BIRTHDAY, "1990", COLUMN::NONE, string() };
+	result = employeeManager.search(option2);
 	EXPECT_EQ(1, result.size());
 }
 
@@ -78,9 +117,12 @@ TEST(EmployeeManagerHMTest, ModifyByBirthYearTest)
 	
 	std::map<int, Employee> result;
 
-	employeeManager.ModifyByBirthYear("BirthYear", "1987", "birthday", "19970402");
-	result = employeeManager.SearchByBirthMonth("BirthMonth", "04");
+	Option option1 = { COMMAND::MOD, OPTION1::NONE, OPTION2::YEAR, Employee(), COLUMN::BIRTHDAY, "1987", COLUMN::BIRTHDAY, "19970402" };
+	result = employeeManager.execute(&employeeManager.search(option1), option1);
+	result.clear();
 
+	Option option2 = { COMMAND::SCH, OPTION1::NONE, OPTION2::MONTH, Employee(), COLUMN::BIRTHDAY, "04", COLUMN::NONE, string() };
+	result = employeeManager.search(option2);
 	EXPECT_EQ(1, result.size());
 }
 TEST(EmployeeManagerHMTest, ModifyByBirthMonthTest)
@@ -90,9 +132,12 @@ TEST(EmployeeManagerHMTest, ModifyByBirthMonthTest)
 	
 	std::map<int, Employee> result;
 
-	employeeManager.ModifyByBirthMonth("BirthMonth", "11", "birthday", "19770819");
-	result = employeeManager.SearchByBirthDay("BirthDay", "19");
+	Option option1 = { COMMAND::MOD, OPTION1::NONE, OPTION2::MONTH, Employee(), COLUMN::BIRTHDAY, "11", COLUMN::BIRTHDAY, "19770819" };
+	result = employeeManager.execute(&employeeManager.search(option1), option1);
+	result.clear();
 
+	Option option2 = { COMMAND::SCH, OPTION1::NONE, OPTION2::DAY, Employee(), COLUMN::BIRTHDAY, "19", COLUMN::NONE, string() };
+	result = employeeManager.search(option2);
 	EXPECT_EQ(3, result.size());
 }
 
@@ -103,9 +148,12 @@ TEST(EmployeeManagerHMTest, ModifyByBirthDayTest)
 
 	std::map<int, Employee> result;
 
-	employeeManager.ModifyByBirthDay("BirthDay", "19", "name", "Hyeonmin Koe");
-	result = employeeManager.SearchByFirstName("FirstName", "Hyeonmin");
+	Option option1 = { COMMAND::MOD, OPTION1::NONE, OPTION2::DAY, Employee(), COLUMN::BIRTHDAY, "19", COLUMN::NAME, "Hyeonmin Koe" };
+	result = employeeManager.execute(&employeeManager.search(option1), option1);
+	result.clear();
 
+	Option option2 = { COMMAND::SCH, OPTION1::NONE, OPTION2::FIRST_NAME, Employee(), COLUMN::NAME, "Hyeonmin", COLUMN::NONE, string() };
+	result = employeeManager.search(option2);
 	EXPECT_EQ(2, result.size());
 }
 

--- a/UnitTest/Parser_Unittest.cpp
+++ b/UnitTest/Parser_Unittest.cpp
@@ -2,6 +2,7 @@
 #include "../GCR Project/Employee.h"
 #include "../GCR Project/EmployeeManager.h"
 #include "../GCR Project/Parser.cpp"
+#include "../GCR Project/common.cpp"
 
 
 TEST(ParserTest, ParserAdd) {
@@ -28,15 +29,15 @@ TEST(ParserTest, ParserDELbyname) {
 TEST(ParserTest, ParserSRHdefult) {
 	Parser parser;
 	parser.parse("ADD, , , ,15123099,BMU MPOSXU,CL3,010-3112-2609,19770901,ADV");
-	EXPECT_EQ(parser.parse("SCH,-p, , , certi, ADV"), "SCH,15123099,BMU MPOSXU,CL3,010-3112-2609,19770901,ADV");
+	EXPECT_EQ(parser.parse("SCH,-p, , ,certi,ADV"), "SCH,15123099,BMU MPOSXU,CL3,010-3112-2609,19770901,ADV");
 	EXPECT_TRUE(true);
 }
 
 TEST(ParserTest, ParserSRHNone) {
 	Parser parser;
 	parser.parse("ADD, , , ,15123099,BMU MPOSXU,CL3,010-3112-2609,19770901,ADV");
-	string str = parser.parse("SCH,-p, , ,birthday,10");
-	EXPECT_EQ(str.compare(""), 0);
+	string str = parser.parse("SCH,-p, , ,birthday,19770901");
+	EXPECT_EQ(str.compare("SCH,15123099,BMU MPOSXU,CL3,010-3112-2609,19770901,ADV"), 0);
 	EXPECT_TRUE(true);
 }
 


### PR DESCRIPTION
1. EmployeeManager의 search / execute의 기능을 추상화된 factory pattern으로 나눔
2. Option 구조체와 그를 이용하는 Parser interface 구현
3. Option 구조체와 관련된 common code 추가
4. EmployeeManager의 변경되구조로의 unittest 수정
5. class diagram 추가